### PR TITLE
Fixed reference to renamed `GRAMMAR.ABNF` file from spec repo.

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -96,7 +96,7 @@
     {{ end -}}
         </li></ul>
     </nav>
-    {{- replace $spec "%%GRAMMAR.ABNF%%" (transform.Highlight (partial "grammar.html" . ) "abnf") 1 | replaceRE "id=\"([^\"]+)\"" "id=\"spec-$1\"" | safeHTML -}}
+    {{- replace $spec "%%GRAMMAR%%" (transform.Highlight (partial "grammar.html" . ) "abnf") 1 | replaceRE "id=\"([^\"]+)\"" "id=\"spec-$1\"" | safeHTML -}}
 </article>
 {{- end -}}
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -59,7 +59,7 @@
 </article>
 {{- end -}}
 
-{{ with readFile "spec/GRAMMAR" -}}
+{{ with readFile "spec/GRAMMAR.ABNF" -}}
 {{ $spec := partial "spec.html" . }}
 <article id="specification">
     <h1>Syntax</h1>
@@ -96,7 +96,7 @@
     {{ end -}}
         </li></ul>
     </nav>
-    {{- replace $spec "%%GRAMMAR%%" (transform.Highlight (partial "grammar.html" . ) "abnf") 1 | replaceRE "id=\"([^\"]+)\"" "id=\"spec-$1\"" | safeHTML -}}
+    {{- replace $spec "%%GRAMMAR.ABNF%%" (transform.Highlight (partial "grammar.html" . ) "abnf") 1 | replaceRE "id=\"([^\"]+)\"" "id=\"spec-$1\"" | safeHTML -}}
 </article>
 {{- end -}}
 


### PR DESCRIPTION
As explained in the [jmespath.spec](https://github.com/jmespath-community/jmespath.spec/pull/57) repository, the `GRAMMAR` file conflicts with the `grammar/` folder with the same name on Windows.

This PR fixes the reference to the, now renamed, `GRAMMAR.ABNF` file.