### PR TITLE
Supports devcontainer.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,31 @@
+FROM klakegg/hugo:0.95.0-ext-ubuntu-ci
+
+RUN apt-get update \
+ && apt-get install -y curl nmap \
+ && curl -L https://github.com/jmespath/jp/releases/download/0.2.1/jp-linux-amd64 --output /usr/local/bin/jp \
+ && chmod +x /usr/local/bin/jp \
+ && ln -s /usr/local/bin/jp /src/jp
+
+COPY ./.devcontainer/start.sh /start.sh
+RUN chmod +x /start.sh
+
+ENV HUGO_EDITON extended
+ENV HUGO_VERSION_OVERRIDE 0.97.0
+ENV HUGO_VERSION 0.97.0
+
+## To build this image, the following incorrect command was run:
+## `hugo gen autocomplete > /etc/bash_completion.d/hugo.sh`
+## (see https://github.com/klakegg/docker-hugo/blob/847a21f53c4074721573bb7e38e3fe61e593755c/src/files/_script/hugo-extended.sh#L48)
+## To fix the incorrectly generated file we need to run the following command instead:
+## `hugo completion bash > /etc/bash_completion.d/hugo.sh` 
+##
+## Unfortunately, running Hugo for the first time will print "Downloading Hugo 0.97.0" on stdout.
+## To prevent this line from being added to the bash_completion script and thus creating a corrupt file,
+## we run Hugo a first time to force download to happen.
+##
+## Once installed, we can run Hugo safely the second time.
+## 
+RUN hugo --help >/dev/null \
+ && hugo completion bash >/etc/bash_completion.d/hugo.sh
+
+CMD [ "/start.sh" ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,15 @@
 	"workspaceMount": "source=${localWorkspaceFolder},target=/src,type=bind,consistency=cached",
 	"workspaceFolder": "/src",
 
+	// Mount SSH keys to support Git interactions
+	// When using default root user, the $HOME directory is /tmp
+	// Change the target mount if using a non-root user.
+	"mounts": [
+		// this supports both Mac OS|Linux and Windows hosts
+		// only one of the environment variable will expand
+		"source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/tmp/.ssh,type=bind,consistency=cached"
+	],
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
     	"terminal.integrated.defaultProfile.linux": "shell",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+{
+	"name": "Hugo",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": "..",
+		"args": {}
+	},
+
+	"workspaceMount": "source=${localWorkspaceFolder},target=/src,type=bind,consistency=cached",
+	"workspaceFolder": "/src",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+    	"terminal.integrated.defaultProfile.linux": "shell",
+    	"terminal.integrated.profiles.linux": {
+    	    "shell": {
+    	        "path": "/src/.devcontainer/hugo-shell.sh",
+    	    }
+    	},
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"budparr.language-hugo-vscode",
+		"bungcip.better-toml"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [ 1313 ],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "/start.sh",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	//"remoteUser": "vscode",
+
+	"features": {
+		"github-cli": "latest"
+	}
+}

--- a/.devcontainer/hugo-shell.sh
+++ b/.devcontainer/hugo-shell.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+hugo shell

--- a/.devcontainer/start.sh
+++ b/.devcontainer/start.sh
@@ -9,7 +9,7 @@ if [[ ! -f "/src/jp" ]]; then
 fi
 
 ## The static website pulls most of its contents
-## from the jmespath.spec site and corresponding wiki.
+## from the jmespath.spec repository and corresponding wiki.
 ## Clone those repositories here as a courtesy
 
 if [[ ! -d "/src/content/spec" ]]; then
@@ -25,6 +25,7 @@ fi
 
 rm /src/data/functions
 ln -s /src/content/spec/functions /src/data/functions
+git update-index --assume-unchanged /src/data/functions
 
 ## Start local server to process JMESPath expressions
 ## This is required during static site genration and

--- a/.devcontainer/start.sh
+++ b/.devcontainer/start.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+## This devcontainer is mounting the workspace
+## in the /src folder which gets its original contents ignored.
+## We need to recreate the symlink to /usr/local/bin/jp
+
+if [[ ! -f "/src/jp" ]]; then
+  ln -s /usr/local/bin/jp /src/jp
+fi
+
+## The static website pulls most of its contents
+## from the jmespath.spec site and corresponding wiki.
+## Clone those repositories here as a courtesy
+
+if [[ ! -d "/src/content/spec" ]]; then
+  git clone --depth 1 https://github.com/jmespath-community/jmespath.spec.git /src/content/spec/
+fi
+if [[ ! -d "/src/content/wiki" ]]; then
+  git clone --depth 1 https://github.com/jmespath-community/jmespath.spec.wiki.git /src/content/wiki/
+fi
+
+## This repository uses symlinks
+## If you are starting this devcontainer from Windows
+## we fix this transparently here
+
+rm /src/data/functions
+ln -s /src/content/spec/functions /src/data/functions
+
+## Start local server to process JMESPath expressions
+## This is required during static site genration and
+## to power the live samples from the website.
+## It can be called with a simple curl command:
+## curl -X POST --location http://localhost:8000/json.txt  \
+## -H 'Content-Type: text/plain' \
+## --data-binary @- << EOF
+## foo
+## {"foo": "bar"}
+## EOF
+##
+
+ncat -lk -p 8000 -e ".github/workflows/jp_service.sh" &
+
+## Serve static web site
+
+hugo server

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 content/spec/
 content/wiki/
+public/
+resources/
+
+\.hugo_build\.lock
+
+jp


### PR DESCRIPTION
@innovate-invent  I finally got around to create my devcontainer-based environment.
This allows anyone to start cloning the repository and apply the guidelines from the README to quickly have an up and running development environment.

That also helps me who mostly uses Windows for most tasks.

I have been able to spend a short amount of time navigating around the website.
The continuous scrolling virtual pages is something to get used to, I must say 😉.