### PR TITLE
Sort examples

### DIFF
--- a/themes/jmespath/layouts/partials/function.html
+++ b/themes/jmespath/layouts/partials/function.html
@@ -75,7 +75,7 @@
         </thead>
         <tbody>
         {{- $inTests := false }}
-        {{ range .examples }}
+        {{ range sort .examples "context" }}
             {{ $context := jsonify .context | safeHTML -}}
             {{ if gt (len $context) 60 -}}{{if not $inTests}}<tr class="more" onclick="event.currentTarget.parentElement.classList.toggle('showall')"><td colspan="3">Show more..</td></tr>{{ end }}{{ $inTests = true }}{{ end -}}
             <tr {{ if $inTests }}class="test"{{ end }}><td>{{ $context }}</td><td>{{ $name }}({{ delimit .args ", " }})</td><td>{{ .returns | jsonify | safeHTML }}</td></tr>

--- a/themes/jmespath/layouts/partials/grammar.html
+++ b/themes/jmespath/layouts/partials/grammar.html
@@ -1,7 +1,7 @@
 {{ $scratch := newScratch -}}
 {{ $scratch.Set "inHead" true -}}
 {{ $scratch.Set "result" "" -}}
-{{ range split . "\n" -}}
+{{ range split . "\r\n" -}}
 {{ with index (split . ";;") 0 -}}
     {{ if not (and ($scratch.Get "inHead") (eq (substr . 0 1) ";")) -}}
         {{ $scratch.Set "inHead" false -}}

--- a/themes/jmespath/layouts/partials/spec.html
+++ b/themes/jmespath/layouts/partials/spec.html
@@ -21,7 +21,7 @@
 {{ $scratch.Set "id" "" -}}
 {{ $scratch.Set "expressions" slice -}}
 {{ $scratch.Set "body" slice -}}
-{{ range split . "\n" -}}
+{{ range split . "\r\n" -}}
 {{ if not (and ($scratch.Get "inHead") (eq (substr . 0 1) ";")) -}}
 {{ $scratch.Set "inHead" false -}}
 {{ with $line := split . ";;" -}}


### PR DESCRIPTION
Sort examples by context length to deal with Hugo not preserving ordering of mappings.
This is a better approach anyway as the main criteria to display an example is its context length.

There is also a fix for abnf line endings snuck in.