### PR TITLE
Fix demo result box background

### DIFF
--- a/themes/jmespath/assets/main.scss
+++ b/themes/jmespath/assets/main.scss
@@ -121,7 +121,7 @@ header {
     .result {
       margin-top: 2em;
       position: relative;
-      background-color: inherit;
+      background-color: transparent;
     }
   }
 


### PR DESCRIPTION
`inherit` works here, but I meant `transparent` to match behavior of the former div.